### PR TITLE
Add interface library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ enable_testing()
 
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
+include(compiler-flags)
+
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -13,12 +15,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   # Set the possible values of build type for cmake-gui
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
     "MinSizeRel" "RelWithDebInfo")
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wshadow")
-elseif(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
 endif()
 
 find_package(Git QUIET)

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -1,0 +1,17 @@
+add_library(hpwhsim_interface_library INTERFACE)
+
+target_compile_options(hpwhsim_interface_library INTERFACE
+$<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
+    /W4   # Warning level (default is W3)
+    #/WX  # Turn warnings into errors
+  >
+
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>: # GCC and Clang
+    -Wall       # Turn on all warnings
+    -Wextra     # Turn on extra warnings
+    -Wpedantic  # Turn on warning not covered in Wall and Wextra
+    #-Werror    # Turn warnings into errors
+    -fpic       # Position Independent Code
+    -Wshadow
+  >
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,5 @@ add_dependencies(libHPWHsim ${PROJECT_NAME}_version_header)
 set_target_properties(libHPWHsim PROPERTIES OUTPUT_NAME HPWHsim)
 set_target_properties(libHPWHsim PROPERTIES PDB_NAME libHPWHsim)
 target_link_libraries(libHPWHsim PRIVATE hpwhsim_interface_library)
-target_compile_features(libHPWHsim PRIVATE cxx_std_17)
 
 target_include_directories(libHPWHsim PUBLIC ${PROJECT_SOURCE_DIR}/vendor/btwxt/src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ add_dependencies(libHPWHsim ${PROJECT_NAME}_version_header)
 
 set_target_properties(libHPWHsim PROPERTIES OUTPUT_NAME HPWHsim)
 set_target_properties(libHPWHsim PROPERTIES PDB_NAME libHPWHsim)
-target_compile_features(libHPWHsim PUBLIC cxx_std_17)
+target_link_libraries(libHPWHsim PRIVATE hpwhsim_interface_library)
+target_compile_features(libHPWHsim PRIVATE cxx_std_17)
 
 target_include_directories(libHPWHsim PUBLIC ${PROJECT_SOURCE_DIR}/vendor/btwxt/src)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(testHeatingLogics testHeatingLogics.cc)
 set(libs
  libHPWHsim 
  btwxt
+ hpwhsim_interface_library
 )
 target_link_libraries(testTool ${libs})
 target_link_libraries(testTankSizeFixed ${libs})


### PR DESCRIPTION
## Description

Replace CMAKE flags for an interface library, as this is a more appropriate method to set flags for a library.

## Changes 

- Adds compiler-flag.cmake to contain the interface library.
- Remove c++11 flag
- This change brought up some warnings for msvc, they will be addressed in a PR to clean up warnings and set Werror.

## Test

- Runs locally
- GCC contains an error when running locally.